### PR TITLE
Update nodejs version to 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         - Ubuntu-18.04
         - Ubuntu-20.04
         nodejs:
-        - 12
+        - 16
       fail-fast: false
     steps:
     - name: Turn off auto-crlf

--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ inputs:
     required: false
     default: "fail"
 runs:
-  using: "node12"
+  using: "node16"
   main: "lib/index.js"


### PR DESCRIPTION
This PR updates the nodejs matrix version to 16.
As recommended by GitHub with the following warning: 
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: shimataro/ssh-key-action
```

Solves #207 