### PR TITLE
Feat: Only try deleting files that were created by the action during cleanup phase

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,9 @@ export function main(): void {
         }
 
         fs.writeFileSync(pathName, file.contents, file.options);
-        createdFileNames.push(file.name);
+        if (file.mustNotExist === true) {
+            createdFileNames.push(file.name);
+        }
     }
     common.saveCreatedFileNames(createdFileNames);
 


### PR DESCRIPTION
* At the moment, the action can delete files during the cleanup phase that were potentially not created by it.
* The PR suggests only doing so if the file is guaranteed to have been created by the action (i.e. has `mustNotExist` set to `true`).