### PR TITLE
Fix typo in the YAML action block of newly added section for HOME env

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ If this error occurs, try specifying the environment variable `HOME` as follows.
 
 ```yaml
 - name: Install SSH key
-  ses: shimataro/ssh-key-action@v2
+  uses: shimataro/ssh-key-action@v2
   env:
     HOME: /root
   with:


### PR DESCRIPTION
This pull request makes a minor correction in the `README.md` file, fixing a typo in the GitHub Actions workflow example concerning the newly added section for HOME env.

The change replaces the incorrect `ses:` key with the correct `uses:` key for specifying an action.