### PR TITLE
Upgrade to use node24 runner

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,6 @@ inputs:
     required: false
     default: "fail"
 runs:
-  using: "node20"
+  using: "node24"
   main: "./dist/main.js"
   post: "./dist/post.js"


### PR DESCRIPTION
- As per [the deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), node 20 is no longer supported as a runner base
- The [PR that updated the code to support node 24](https://github.com/shimataro/ssh-key-action/pull/278) forgot to update the base